### PR TITLE
docs: pin spec references + gh workflow helpers (#125)

### DIFF
--- a/docs/github_cli_workflow.md
+++ b/docs/github_cli_workflow.md
@@ -1,0 +1,98 @@
+### GitHub CLI workflow (milestones, tickets, PRs)
+
+This repo is set up for **GitHub CLI-first** workflow using `gh`.
+
+Pre-reqs:
+- `gh auth status` shows you’re logged in
+- repo remote is set (`git remote -v`)
+
+## 1) Templates: how they work
+
+The repo contains:
+- Issue templates: `.github/ISSUE_TEMPLATE/*.yml`
+- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
+
+Once these files are **committed and pushed**, GitHub uses them automatically:
+- UI: Issues → “New issue” shows template choices
+- CLI: `gh issue create --template <filename>.yml`
+- PRs: opening a PR will prefill from the PR template
+
+## 2) Milestones (CLI)
+
+GitHub doesn’t have a built-in `gh milestone create` command, so use the API.
+
+Create milestones (example: A–G from `docs/public_testnet_plan.md`):
+
+```bash
+REPO="catalyst-network/catalyst-node-rust"
+
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone A — Spec pinning + canonical boundaries"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone B — Transaction pipeline"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone C — Membership / worker pool"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone D — 4-phase consensus (protocol-faithful)"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone E — State application + authenticated queries"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone F — Public testnet ops + safety defaults"
+gh api -X POST "repos/$REPO/milestones" -f title="Milestone G — Testing + release gate"
+```
+
+List milestones:
+
+```bash
+gh api "repos/$REPO/milestones" --paginate -q '.[] | "\(.number)\t\(.title)\t\(.state)"'
+```
+
+## 3) Creating issues (CLI, non-interactive)
+
+The `--template` flow is interactive. For repeatable automation (what we’ll use together),
+create issues with a prebuilt body.
+
+Example (spec ticket):
+
+```bash
+REPO="catalyst-network/catalyst-node-rust"
+MILESTONE_TITLE="Milestone A — Spec pinning + canonical boundaries"
+
+cat > /tmp/issue.md <<'EOF'
+Spec reference (section/page):
+- Consensus v1.2 §4.5 (Transaction validity), p.__–__
+
+Problem statement:
+- <what’s missing/incorrect today>
+
+Scope (in/out):
+In:
+- ...
+Out:
+- ...
+
+Acceptance criteria:
+- ...
+
+Test plan:
+- Unit:
+- Local testnet:
+  - make testnet-down
+  - make testnet-up
+  - make testnet-status
+  - make testnet-contract-test
+  - make testnet-down
+
+Code areas (expected):
+- crates/...
+EOF
+
+gh issue create \
+  --repo "$REPO" \
+  --title "[Spec] <short description>" \
+  --body-file /tmp/issue.md \
+  --label spec \
+  --milestone "$MILESTONE_TITLE"
+```
+
+## 4) Commit/push cadence (recommended)
+
+- One PR per coherent change (small, reviewable).
+- For “testnet-impacting” changes, use as a gate:
+  - `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
+- Push early; open a draft PR if needed; keep commits frequent.
+

--- a/docs/spec_index.md
+++ b/docs/spec_index.md
@@ -6,21 +6,33 @@ This repo’s source of truth is the published PDFs:
 
 Use this index when creating GitHub tickets so each ticket has an explicit **spec reference** (section/page).
 
+## Spec pin (what we are implementing against)
+
+- **Consensus**: “Catalyst Network Research: a new Consensus Protocol” — **Version 1.2** (“Currently under review”).  
+  Source: [CatalystConsensusPaper.pdf](https://catalystnet.org/media/CatalystConsensusPaper.pdf)
+- **Network overview**: “Introduction to Catalyst Network”.  
+  Source: [IntroductionToCatalystNetwork.pdf](https://catalystnet.org/media/IntroductionToCatalystNetwork.pdf)
+
+Ticket/PR reference format:
+
+- `Consensus v1.2 §X.Y (p.NN–NN): <short requirement>`
+- `Network intro §X.Y (p.NN–NN): <short requirement>`
+
 ## Consensus paper (v1.2) — key areas
 
-- **Producer nodes selection**: §2.2.1
-- **Transaction types**: §4.1
-- **Transaction structure**: §4.2
-- **Transaction entries**: §4.3
-- **Transaction signature**: §4.4
-- **Transaction validity**: §4.5
-- **Consensus protocol overview**: §5.2
-  - **Construction phase**: §5.2.1
-  - **Campaigning phase**: §5.2.2
-  - **Voting phase**: §5.2.3
-  - **Synchronisation phase**: §5.2.4
+- **Producer nodes selection**: §2.2.1 (p.17)
+- **Transaction types**: §4.1 (p.26)
+- **Transaction structure**: §4.2 (p.26)
+- **Transaction entries**: §4.3 (p.27)
+- **Transaction signature**: §4.4 (p.29)
+- **Transaction validity**: §4.5 (p.32)
+- **Consensus protocol overview**: §5.2 (p.37)
+  - **Construction phase**: §5.2.1 (p.37)
+  - **Campaigning phase**: §5.2.2 (p.39)
+  - **Voting phase**: §5.2.3 (p.41)
+  - **Synchronisation phase**: §5.2.4 (p.44)
 - **DFS + producer output**: see §5.2.4 and security notes around LSU production in Ch.6
-- **Security considerations**: Ch.6 (notably selection, LSU production, signature scheme)
+- **Security considerations**: Ch.6 (p.47) (notably selection, LSU production, signature scheme)
 
 ## Network intro — key areas
 

--- a/scripts/gh/create_issue_from_stdin.sh
+++ b/scripts/gh/create_issue_from_stdin.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create an issue using a body read from stdin (non-interactive).
+#
+# Usage:
+#   cat body.md | scripts/gh/create_issue_from_stdin.sh \
+#     --title "[Spec] ..." \
+#     --label spec \
+#     --milestone 1
+#
+# Env:
+#   REPO (default catalyst-network/catalyst-node-rust)
+
+REPO="${REPO:-catalyst-network/catalyst-node-rust}"
+
+TITLE=""
+LABELS=""
+MILESTONE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --title) TITLE="$2"; shift 2 ;;
+    --label) LABELS="$LABELS $2"; shift 2 ;;
+    --milestone) MILESTONE="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$TITLE" ] || { echo "missing --title" >&2; exit 2; }
+
+tmp="$(mktemp)"
+cat > "$tmp"
+
+args=(--repo "$REPO" --title "$TITLE" --body-file "$tmp")
+
+if [ -n "$MILESTONE" ]; then
+  args+=(--milestone "$MILESTONE")
+fi
+
+if [ -n "$LABELS" ]; then
+  # shellcheck disable=SC2086
+  for l in $LABELS; do
+    args+=(--label "$l")
+  done
+fi
+
+gh issue create "${args[@]}"

--- a/scripts/gh/create_milestones.sh
+++ b/scripts/gh/create_milestones.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-catalyst-network/catalyst-node-rust}"
+
+create() {
+  local title="$1"
+  gh api -X POST "repos/$REPO/milestones" -f "title=$title" >/dev/null
+  echo "created milestone: $title"
+}
+
+create "Milestone A — Spec pinning + canonical boundaries"
+create "Milestone B — Transaction pipeline"
+create "Milestone C — Membership / worker pool"
+create "Milestone D — 4-phase consensus (protocol-faithful)"
+create "Milestone E — State application + authenticated queries"
+create "Milestone F — Public testnet ops + safety defaults"
+create "Milestone G — Testing + release gate"
+


### PR DESCRIPTION
Closes #125.

- Adds a spec pin + section/page anchors in `docs/spec_index.md`.
- Documents CLI-first issue/milestone workflow in `docs/github_cli_workflow.md`.
- Adds helper scripts under `scripts/gh/` for creating milestones and creating issues non-interactively.

Spec refs:
- Consensus v1.2: https://catalystnet.org/media/CatalystConsensusPaper.pdf
- Network intro: https://catalystnet.org/media/IntroductionToCatalystNetwork.pdf