### PR TITLE
spec: add consensus-critical test vectors (A6 #130)

### DIFF
--- a/crates/catalyst-core/examples/print_test_vectors.rs
+++ b/crates/catalyst-core/examples/print_test_vectors.rs
@@ -1,0 +1,63 @@
+use catalyst_core::protocol as p;
+
+fn hex32(b: &[u8; 32]) -> String {
+    format!("0x{}", hex::encode(b))
+}
+
+fn hex_bytes(b: &[u8]) -> String {
+    format!("0x{}", hex::encode(b))
+}
+
+fn main() {
+    // --- Transaction signing payload + txid vector ---
+    let from_pk = [1u8; 32];
+    let to_pk = [2u8; 32];
+
+    let core = p::TransactionCore {
+        tx_type: p::TransactionType::NonConfidentialTransfer,
+        entries: vec![
+            p::TransactionEntry {
+                public_key: from_pk,
+                amount: p::EntryAmount::NonConfidential(-5),
+            },
+            p::TransactionEntry {
+                public_key: to_pk,
+                amount: p::EntryAmount::NonConfidential(5),
+            },
+        ],
+        nonce: 1,
+        lock_time: 0,
+        fees: 0,
+        data: Vec::new(),
+    };
+    let timestamp = 123u64;
+
+    let payload = p::transaction_signing_payload(&core, timestamp).unwrap();
+    let tx = p::Transaction {
+        core: core.clone(),
+        signature: p::AggregatedSignature(vec![0u8; 64]),
+        timestamp,
+    };
+    let txid = p::transaction_id(&tx).unwrap();
+
+    println!("tx_signing_payload_hex={}", hex_bytes(&payload));
+    println!("tx_id_hex={}", hex32(&txid));
+
+    // --- Producer selection vector ---
+    let seed: p::Hash32 = [42u8; 32];
+    let workers: Vec<p::WorkerId> = (0u8..10u8)
+        .map(|i| {
+            let mut id = [0u8; 32];
+            id[0] = i;
+            id
+        })
+        .collect();
+    let selected = p::select_producers_for_next_cycle(&workers, &seed, 4);
+
+    println!("producer_seed_hex={}", hex32(&seed));
+    println!("producer_selected_count={}", selected.len());
+    for (i, w) in selected.iter().enumerate() {
+        println!("producer_selected_{}_hex={}", i, hex32(w));
+    }
+}
+

--- a/crates/catalyst-core/tests/test_vectors.rs
+++ b/crates/catalyst-core/tests/test_vectors.rs
@@ -1,0 +1,94 @@
+use catalyst_core::protocol as p;
+
+#[test]
+fn tx_signing_payload_vector() {
+    let from_pk = [1u8; 32];
+    let to_pk = [2u8; 32];
+
+    let core = p::TransactionCore {
+        tx_type: p::TransactionType::NonConfidentialTransfer,
+        entries: vec![
+            p::TransactionEntry {
+                public_key: from_pk,
+                amount: p::EntryAmount::NonConfidential(-5),
+            },
+            p::TransactionEntry {
+                public_key: to_pk,
+                amount: p::EntryAmount::NonConfidential(5),
+            },
+        ],
+        nonce: 1,
+        lock_time: 0,
+        fees: 0,
+        data: Vec::new(),
+    };
+    let timestamp = 123u64;
+
+    let payload = p::transaction_signing_payload(&core, timestamp).unwrap();
+    assert_eq!(
+        format!("0x{}", hex::encode(payload)),
+        "0x000000000200000000000000010101010101010101010101010101010101010101010101010101010101010100000000fbffffffffffffff0202020202020202020202020202020202020202020202020202020202020202000000000500000000000000010000000000000000000000000000000000000000000000000000007b00000000000000"
+    );
+}
+
+#[test]
+fn tx_id_vector() {
+    let from_pk = [1u8; 32];
+    let to_pk = [2u8; 32];
+
+    let core = p::TransactionCore {
+        tx_type: p::TransactionType::NonConfidentialTransfer,
+        entries: vec![
+            p::TransactionEntry {
+                public_key: from_pk,
+                amount: p::EntryAmount::NonConfidential(-5),
+            },
+            p::TransactionEntry {
+                public_key: to_pk,
+                amount: p::EntryAmount::NonConfidential(5),
+            },
+        ],
+        nonce: 1,
+        lock_time: 0,
+        fees: 0,
+        data: Vec::new(),
+    };
+    let timestamp = 123u64;
+
+    let tx = p::Transaction {
+        core,
+        signature: p::AggregatedSignature(vec![0u8; 64]),
+        timestamp,
+    };
+    let txid = p::transaction_id(&tx).unwrap();
+    assert_eq!(
+        format!("0x{}", hex::encode(txid)),
+        "0x40385854022fe17953c55fddd2fdd62a9ab0baa830282ec143460b64534e9177"
+    );
+}
+
+#[test]
+fn producer_selection_vector() {
+    let seed: p::Hash32 = [42u8; 32];
+    let workers: Vec<p::WorkerId> = (0u8..10u8)
+        .map(|i| {
+            let mut id = [0u8; 32];
+            id[0] = i;
+            id
+        })
+        .collect();
+
+    let selected = p::select_producers_for_next_cycle(&workers, &seed, 4);
+    let got: Vec<String> = selected.iter().map(|id| format!("0x{}", hex::encode(id))).collect();
+
+    assert_eq!(
+        got,
+        vec![
+            "0x0800000000000000000000000000000000000000000000000000000000000000".to_string(),
+            "0x0900000000000000000000000000000000000000000000000000000000000000".to_string(),
+            "0x0200000000000000000000000000000000000000000000000000000000000000".to_string(),
+            "0x0300000000000000000000000000000000000000000000000000000000000000".to_string(),
+        ]
+    );
+}
+

--- a/docs/test_vectors.md
+++ b/docs/test_vectors.md
@@ -1,0 +1,58 @@
+### Catalyst test vectors (Wire v1 / public testnet MVP)
+
+These vectors are used to **lock down determinism** for consensus-critical hashing and selection.
+They are asserted in tests so changes to encoding/hashing/selection cannot slip in unnoticed.
+
+Spec references:
+- Consensus v1.2 §4.2–§4.5 (transaction structure/signature/validity): `https://catalystnet.org/media/CatalystConsensusPaper.pdf`
+- Consensus v1.2 §2.2.1 (producer selection): `https://catalystnet.org/media/CatalystConsensusPaper.pdf`
+
+## Vector 1 — Transaction signing payload
+
+Definition (current implementation):
+- `payload = bincode(TransactionCore) || timestamp_le`
+
+Inputs:
+- `tx_type = NonConfidentialTransfer`
+- entries:
+  - from: `0x01…01` (32 bytes of `0x01`), amount `-5`
+  - to: `0x02…02` (32 bytes of `0x02`), amount `+5`
+- `nonce = 1`
+- `lock_time = 0`
+- `fees = 0`
+- `data = []`
+- `timestamp = 123`
+
+Expected:
+- `tx_signing_payload_hex = 0x000000000200000000000000010101010101010101010101010101010101010101010101010101010101010100000000fbffffffffffffff0202020202020202020202020202020202020202020202020202020202020202000000000500000000000000010000000000000000000000000000000000000000000000000000007b00000000000000`
+
+## Vector 2 — Transaction id (txid)
+
+Definition (current implementation):
+- `tx_id = blake2b_256(bincode(Transaction))`
+
+Inputs:
+- same as Vector 1, with signature bytes set to 64 zeros
+
+Expected:
+- `tx_id_hex = 0x40385854022fe17953c55fddd2fdd62a9ab0baa830282ec143460b64534e9177`
+
+## Vector 3 — Producer selection ordering (Id_i XOR r_{n+1})
+
+Definition (current implementation):
+- `r_{n+1} = blake2b_256(seed || DOMAIN_TAG)` (see ADR 0003)
+- `u_i = Id_i XOR r_{n+1}`
+- sort by `u_i` ascending; choose first `P`
+
+Inputs:
+- `seed = 0x2a…2a` (32 bytes of `0x2a`)
+- worker pool: 10 ids where `id[i] = [i, 0, 0, …]` for i=0..9
+- `P = 4`
+
+Expected:
+- selected producers (in order):
+  - `0x0800…00`
+  - `0x0900…00`
+  - `0x0200…00`
+  - `0x0300…00`
+


### PR DESCRIPTION
Closes #130.

### What
- Adds deterministic test vectors for:
  - tx signing payload (`bincode(TransactionCore) || timestamp_le`)
  - canonical txid (`blake2b_256(bincode(Transaction))`)
  - producer selection ordering (fixed worker pool + seed)
- Documents the vectors in `docs/test_vectors.md`.
- Adds assertions in `crates/catalyst-core/tests/test_vectors.rs`.
- Adds a helper generator `catalyst-core` example to regenerate vectors.

### Spec refs
- Consensus v1.2 §4.2–§4.5, §2.2.1: https://catalystnet.org/media/CatalystConsensusPaper.pdf
