### PR TITLE
spec: canonical tx derivations shared across rpc/node (B1 #137)

### DIFF
--- a/crates/catalyst-cli/src/node.rs
+++ b/crates/catalyst-cli/src/node.rs
@@ -517,25 +517,7 @@ fn load_workers_from_state(store: &StorageManager) -> Vec<[u8; 32]> {
 }
 
 fn tx_sender_pubkey(tx: &catalyst_core::protocol::Transaction) -> Option<[u8; 32]> {
-    match tx.core.tx_type {
-        catalyst_core::protocol::TransactionType::WorkerRegistration => tx.core.entries.get(0).map(|e| e.public_key),
-        catalyst_core::protocol::TransactionType::SmartContract => tx.core.entries.get(0).map(|e| e.public_key),
-        _ => {
-            let mut sender: Option<[u8; 32]> = None;
-            for e in &tx.core.entries {
-                if let catalyst_core::protocol::EntryAmount::NonConfidential(v) = e.amount {
-                    if v < 0 {
-                        match sender {
-                            None => sender = Some(e.public_key),
-                            Some(pk) if pk == e.public_key => {}
-                            Some(_) => return None,
-                        }
-                    }
-                }
-            }
-            sender
-        }
-    }
+    catalyst_core::protocol::transaction_sender_pubkey(tx)
 }
 
 fn tx_to_consensus_entries(tx: &catalyst_core::protocol::Transaction) -> Vec<catalyst_consensus::types::TransactionEntry> {

--- a/crates/catalyst-rpc/src/lib.rs
+++ b/crates/catalyst-rpc/src/lib.rs
@@ -411,25 +411,7 @@ fn verify_tx_signature(tx: &catalyst_core::protocol::Transaction) -> bool {
 }
 
 fn tx_sender_pubkey(tx: &catalyst_core::protocol::Transaction) -> Option<[u8; 32]> {
-    match tx.core.tx_type {
-        catalyst_core::protocol::TransactionType::WorkerRegistration => tx.core.entries.get(0).map(|e| e.public_key),
-        catalyst_core::protocol::TransactionType::SmartContract => tx.core.entries.get(0).map(|e| e.public_key),
-        _ => {
-            let mut sender: Option<[u8; 32]> = None;
-            for e in &tx.core.entries {
-                if let catalyst_core::protocol::EntryAmount::NonConfidential(v) = e.amount {
-                    if v < 0 {
-                        match sender {
-                            None => sender = Some(e.public_key),
-                            Some(pk) if pk == e.public_key => {}
-                            Some(_) => return None,
-                        }
-                    }
-                }
-            }
-            sender
-        }
-    }
+    catalyst_core::protocol::transaction_sender_pubkey(tx)
 }
 
 /// Minimal RPC implementation backed by `catalyst-storage`.

--- a/docs/adr/0005-canonical-transaction-derivations.md
+++ b/docs/adr/0005-canonical-transaction-derivations.md
@@ -1,0 +1,38 @@
+### ADR 0005 — Canonical transaction derivations (txid, sender, lock_time) (B1)
+
+Status: **Accepted (public testnet MVP)**
+
+Related issues:
+- #137 (Milestone B — Transaction pipeline)
+
+Spec references:
+- Consensus v1.2 §4.2–§4.5: `https://catalystnet.org/media/CatalystConsensusPaper.pdf`
+
+## Context / Problem
+
+Multiple parts of the codebase need to derive the same values from the same transaction:
+- tx id (dedupe / persistence key)
+- sender identity (nonce sequencing)
+- lock-time interpretation (not-before)
+
+Historically this logic was duplicated across RPC + node code, which risks divergence.
+
+## Decision (current MVP rules)
+
+Canonical tx object:
+- `catalyst_core::protocol::Transaction`
+
+Canonical derivations:
+- **txid**: `blake2b_256(bincode(Transaction))` via `catalyst_core::protocol::transaction_id`
+- **sender pubkey** (single-sender rule): `catalyst_core::protocol::transaction_sender_pubkey`
+  - registrations / smart contracts: `entries[0].public_key`
+  - transfers: the (single) pubkey with a negative non-confidential amount
+  - multi-sender is rejected for now (returns `None`)
+- **lock_time**: interpreted as unix seconds “not before”
+  - `transaction_is_unlocked(tx, now_secs)` and `validate_basic_and_unlocked(tx, now_secs)`
+
+## Consequences
+
+- RPC, node, and mempool reuse the same derivation rules.
+- Future work (aggregated signatures, confidential transfers) can evolve behind these APIs without duplicating rules.
+


### PR DESCRIPTION
Closes #137.

### What
- Centralizes canonical transaction derivations in `catalyst-core::protocol`:
  - tx sender pubkey (current single-sender rule)
  - lock_time interpretation (unix seconds not-before)
  - validate_basic + unlocked helper
- Removes duplicated sender/lock_time logic from RPC and node paths.
- Adds ADR 0005 documenting canonical tx derivations.

### Spec refs
- Consensus v1.2 §4.2–§4.5: https://catalystnet.org/media/CatalystConsensusPaper.pdf
