### PR TITLE
consensus: producer selection seed from tx signatures root (C2 #145)

### DIFF
--- a/docs/adr/0003-producer-selection-prng-domain-separation.md
+++ b/docs/adr/0003-producer-selection-prng-domain-separation.md
@@ -21,14 +21,16 @@ If the seed derivation or hashing is ambiguous, producer selection can diverge a
 
 The paper describes deriving \(r_{n+1}\) from a previous cycle commitment (it mentions a Merkle root).
 
-In the current codebase, the readily available 32-byte commitment is the **previous cycle LSU hash**
-persisted by the node (see metadata keys like `consensus:last_applied_lsu_hash`).
+In the current codebase, the most direct 32-byte commitment carried by the LSU is the
+**transaction signatures hash root** (`LedgerStateUpdate.partial_update.transaction_signatures_hash`),
+persisted by the node (see metadata keys like `consensus:last_applied_tx_sigs_root`).
 
 Therefore, for public testnet MVP we define:
-- `seed := prev_cycle_commitment_32`, currently the **last applied LSU hash** (32 bytes)
+- `seed := prev_cycle_commitment_32`, currently the **last applied tx signatures root** (32 bytes)
 
 This is a **placeholder mapping** until we implement the paper’s exact commitment (e.g., LSU Merkle root)
-as a first-class stored value.
+as a first-class stored value. For backwards compatibility, the node may fall back to the last applied LSU hash
+if the new seed key is not present.
 
 ### 2) Domain-separated derivation of \(r_{n+1}\)
 


### PR DESCRIPTION
Closes #145.

### What
- Defines an explicit producer-selection seed sourced from `LedgerStateUpdate.partial_update.transaction_signatures_hash`.
- Persists it in storage metadata:
  - `consensus:last_applied_tx_sigs_root`
  - `consensus:last_tx_sigs_root`
  - `consensus:tx_sigs_root:<cycle>`
- Updates producer selection seed load order to prefer the new key, with fallback to legacy `last_applied_lsu_hash`.
- Keeps LSU hash (`consensus:last_lsu_hash`) separate from the producer-selection seed.
- Updates ADR 0003 to reflect the new seed source.

### Testing
- `cargo test -p catalyst-cli`
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
