### PR TITLE
consensus: campaigning witness list + candidate validation (D2 #149)

### DIFF
--- a/crates/catalyst-consensus/src/consensus.rs
+++ b/crates/catalyst-consensus/src/consensus.rs
@@ -357,7 +357,7 @@ impl CollaborativeConsensus {
         // First, consume any previously buffered messages of this type.
         for env in self.drain_pending_by_type(MessageType::ProducerQuantity).await {
             if let Ok(q) = env.extract_message::<ProducerQuantity>() {
-                if q.cycle_number == self.current_cycle {
+                if q.cycle_number == self.current_cycle && self.selected_producers.contains(&q.producer_id) {
                     out.insert(q.producer_id.clone(), q);
                 }
             }
@@ -375,7 +375,7 @@ impl CollaborativeConsensus {
                 Ok(Some(env)) => {
                     if env.message_type == MessageType::ProducerQuantity {
                         if let Ok(q) = env.extract_message::<ProducerQuantity>() {
-                            if q.cycle_number == self.current_cycle {
+                            if q.cycle_number == self.current_cycle && self.selected_producers.contains(&q.producer_id) {
                                 out.insert(q.producer_id.clone(), q);
                             }
                         }
@@ -407,7 +407,7 @@ impl CollaborativeConsensus {
 
         for env in self.drain_pending_by_type(MessageType::ProducerCandidate).await {
             if let Ok(c) = env.extract_message::<ProducerCandidate>() {
-                if c.cycle_number == self.current_cycle {
+                if c.cycle_number == self.current_cycle && self.selected_producers.contains(&c.producer_id) {
                     out.insert(c.producer_id.clone(), c);
                 }
             }
@@ -425,7 +425,7 @@ impl CollaborativeConsensus {
                 Ok(Some(env)) => {
                     if env.message_type == MessageType::ProducerCandidate {
                         if let Ok(c) = env.extract_message::<ProducerCandidate>() {
-                            if c.cycle_number == self.current_cycle {
+                            if c.cycle_number == self.current_cycle && self.selected_producers.contains(&c.producer_id) {
                                 out.insert(c.producer_id.clone(), c);
                             }
                         }
@@ -456,7 +456,7 @@ impl CollaborativeConsensus {
 
         for env in self.drain_pending_by_type(MessageType::ProducerVote).await {
             if let Ok(v) = env.extract_message::<ProducerVote>() {
-                if v.cycle_number == self.current_cycle {
+                if v.cycle_number == self.current_cycle && self.selected_producers.contains(&v.producer_id) {
                     out.insert(v.producer_id.clone(), v);
                 }
             }
@@ -474,7 +474,7 @@ impl CollaborativeConsensus {
                 Ok(Some(env)) => {
                     if env.message_type == MessageType::ProducerVote {
                         if let Ok(v) = env.extract_message::<ProducerVote>() {
-                            if v.cycle_number == self.current_cycle {
+                            if v.cycle_number == self.current_cycle && self.selected_producers.contains(&v.producer_id) {
                                 out.insert(v.producer_id.clone(), v);
                             }
                         }

--- a/crates/catalyst-consensus/src/tests.rs
+++ b/crates/catalyst-consensus/src/tests.rs
@@ -146,6 +146,7 @@ mod integration_tests {
 
         let candidate = result.unwrap();
         assert_eq!(candidate.majority_hash, common_hash);
+        assert!(!candidate.producer_list.is_empty());
     }
 
     #[tokio::test]
@@ -170,10 +171,18 @@ mod integration_tests {
         let mut voting = VotingPhase::new(producer);
 
         // Add candidates with same majority hash
+        // Note: VotingPhase validates producer_list_hash against producer_list (domain-separated).
+        let producer_list = vec!["producer_0".to_string(), "producer_1".to_string()];
+        let expected_hash = blake2b_256_tagged(
+            b"catalyst:campaigning:producer_list:v1",
+            &[producer_list[0].as_bytes(), producer_list[1].as_bytes()],
+        );
         for i in 0..3 {
             voting.add_candidate(ProducerCandidate {
                 majority_hash: [1u8; 32],
-                producer_list_hash: [10u8; 32],
+                producer_list_hash: expected_hash,
+                producer_list: producer_list.clone(),
+                cycle_number: 1,
                 producer_id: format!("producer_{}", i),
                 timestamp: current_timestamp_ms(),
             });
@@ -308,6 +317,7 @@ mod integration_tests {
         let c = ProducerCandidate {
             majority_hash: [2u8; 32],
             producer_list_hash: [3u8; 32],
+            producer_list: vec!["p1".to_string(), "p2".to_string()],
             cycle_number: 1,
             producer_id: "p2".to_string(),
             timestamp: current_timestamp_ms(),
@@ -369,6 +379,7 @@ mod integration_tests {
         let candidate = ProducerCandidate {
             majority_hash: [43u8; 32],
             producer_list_hash: [44u8; 32],
+            producer_list: vec!["test_producer".to_string()],
             cycle_number: 1,
             producer_id: "test_producer".to_string(),
             timestamp: current_timestamp_ms(),

--- a/crates/catalyst-consensus/src/types.rs
+++ b/crates/catalyst-consensus/src/types.rs
@@ -120,6 +120,8 @@ impl_catalyst_serialize!(ProducerQuantity, first_hash, cycle_number, producer_id
 pub struct ProducerCandidate {
     pub majority_hash: Hash,
     pub producer_list_hash: Hash,
+    /// Witness producer list for the majority hash (deterministic ordering required).
+    pub producer_list: Vec<ProducerId>,
     pub cycle_number: CycleNumber,
     pub producer_id: ProducerId,
     pub timestamp: u64,
@@ -143,7 +145,7 @@ impl NetworkMessage for ProducerCandidate {
     }
 }
 
-impl_catalyst_serialize!(ProducerCandidate, majority_hash, producer_list_hash, cycle_number, producer_id, timestamp);
+impl_catalyst_serialize!(ProducerCandidate, majority_hash, producer_list_hash, producer_list, cycle_number, producer_id, timestamp);
 
 /// Producer vote (Voting phase)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -251,6 +253,7 @@ mod wire_roundtrip_tests {
         let msg = ProducerCandidate {
             majority_hash: [2u8; 32],
             producer_list_hash: [3u8; 32],
+            producer_list: vec!["producer_b".to_string()],
             cycle_number: 42,
             producer_id: "producer_b".to_string(),
             timestamp: 123456,


### PR DESCRIPTION
Closes #149.

### What
- Makes Campaigning phase deterministic and verifiable:
  - `ProducerCandidate` now carries the **witness producer list** (`producer_list`) in addition to `producer_list_hash`.
  - Campaigning builds the witness list deterministically (sorted/deduped) and hashes it with domain separation.
  - Voting validates candidates by recomputing `producer_list_hash` from `producer_list` and ignores invalid/wrong-cycle candidates.
- Consensus message collection now filters quantities/candidates/votes by the selected producer set for the cycle.

### Testing
- `cargo test -p catalyst-consensus`
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
