### PR TITLE
consensus: voting compensation + vote validity (D3 #150)

### DIFF
--- a/crates/catalyst-consensus/src/tests.rs
+++ b/crates/catalyst-consensus/src/tests.rs
@@ -194,7 +194,7 @@ mod integration_tests {
             total_new_tokens: 10000,
         };
 
-        let result = voting.execute(2, 0.6, &reward_config).await;
+        let result = voting.execute(2, &reward_config).await;
         assert!(result.is_ok());
 
         let vote = result.unwrap();


### PR DESCRIPTION
Closes #150.

### What
- Makes Voting phase deterministic and stricter:
  - `LedgerStateUpdate.vote_list` now matches the deterministic final vote list used for `vote_list_hash`.
  - Compensation entries are deterministic:
    - deterministic recipient sets (sorted/deduped producers + voters)
    - deterministic even split with remainder handling
    - deterministic placeholder pubkey mapping from producer_id (until membership carries pubkeys)

### Testing
- `cargo test -p catalyst-consensus`
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
