### PR TITLE
sync: LSU CID backfill metadata requests (D4 #151)

### DIFF
--- a/crates/catalyst-cli/src/sync.rs
+++ b/crates/catalyst-cli/src/sync.rs
@@ -12,6 +12,9 @@ pub struct LsuCidGossip {
     pub cycle: u64,
     pub lsu_hash: Hash,
     pub cid: String,
+    /// Previous LSU CID (cycle-1) if known, allowing late-joiners to backfill history.
+    /// Encoded as "" when unknown.
+    pub prev_cid: String,
     /// State root BEFORE applying this LSU (i.e., the expected prev-applied root).
     pub prev_state_root: Hash,
     /// Authenticated state root after applying this LSU.
@@ -22,7 +25,7 @@ pub struct LsuCidGossip {
     pub proof_cid: String,
 }
 
-impl_catalyst_serialize!(LsuCidGossip, cycle, lsu_hash, cid, prev_state_root, state_root, proof_cid);
+impl_catalyst_serialize!(LsuCidGossip, cycle, lsu_hash, cid, prev_cid, prev_state_root, state_root, proof_cid);
 
 impl NetworkMessage for LsuCidGossip {
     fn serialize(&self) -> CatalystResult<Vec<u8>> {
@@ -118,6 +121,37 @@ impl NetworkMessage for FileResponseMsg {
 
     fn message_type(&self) -> MessageType {
         MessageType::FileResponse
+    }
+
+    fn priority(&self) -> u8 {
+        MessagePriority::High as u8
+    }
+
+    fn ttl(&self) -> u32 {
+        30
+    }
+}
+
+/// Request LSU metadata (roots + prev_cid) for a given CID.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LsuMetaRequest {
+    pub requester: String,
+    pub cid: String,
+}
+
+impl_catalyst_serialize!(LsuMetaRequest, requester, cid);
+
+impl NetworkMessage for LsuMetaRequest {
+    fn serialize(&self) -> CatalystResult<Vec<u8>> {
+        CatalystSerialize::serialize(self)
+    }
+
+    fn deserialize(data: &[u8]) -> CatalystResult<Self> {
+        CatalystDeserialize::deserialize(data)
+    }
+
+    fn message_type(&self) -> MessageType {
+        MessageType::ConsensusSync
     }
 
     fn priority(&self) -> u8 {


### PR DESCRIPTION
Closes #151.

### What
- Improves LSU sync for late joiners / restart scenarios:
  - `LsuCidGossip` now includes `prev_cid` (tip back-pointer).
  - Nodes persist a CID->metadata mapping (`consensus:cid_meta:<cid>`) so peers can re-serve LSU metadata.
  - Adds `LsuMetaRequest` so a node that hits a state-root continuity mismatch can request metadata for `prev_cid` and backfill.

### Testing
- `cargo test -p catalyst-cli`
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
