### PR TITLE
docs: public testnet config template + runbook (F1 #162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ You can run a single-node “devnet” that:
 - exposes RPC externally (binds to `0.0.0.0`)
 - prints the bootstrap multiaddr + RPC URL to share
 
+## Public Testnet (operator docs)
+
+- **Config template**: `crates/catalyst-config/configs/public_testnet.toml`
+- **Minimal runbook**: `docs/public_testnet_runbook.md`
+
 Start (replace `HOST` with your public IP or DNS name):
 
 ```bash

--- a/crates/catalyst-config/configs/public_testnet.toml
+++ b/crates/catalyst-config/configs/public_testnet.toml
@@ -1,0 +1,16 @@
+[network]
+name = "testnet"
+p2p_port = 7000
+api_port = 8080
+max_peers = 100
+
+[consensus]
+cycle_duration_ms = 30000  # 30 seconds
+construction_phase_ms = 7500
+campaigning_phase_ms = 7500
+voting_phase_ms = 7500
+synchronization_phase_ms = 7500
+producer_count = 50  # Medium size
+supermajority_threshold = 0.67
+
+# ... etc

--- a/docs/public_testnet_runbook.md
+++ b/docs/public_testnet_runbook.md
@@ -1,0 +1,29 @@
+### Catalyst public testnet runbook (minimal)
+
+### Ports
+- **P2P**: TCP `30333`
+- **RPC (JSON-RPC)**: TCP `8545` (recommended: bind to `127.0.0.1` and put behind a reverse proxy / auth if exposing)
+
+### Config
+- Start from `crates/catalyst-config/configs/public_testnet.toml`.
+- Set these fields before running:
+  - **`[network].bootstrap_peers`**: at least one bootstrap multiaddr
+  - **`[storage].data_dir`**: persistent disk path
+  - **`[dfs].cache_dir`**: persistent disk path
+
+### Safe RPC defaults
+- Keep `rpc.enabled = false` unless you need it.
+- If enabling RPC:
+  - keep `rpc.address = "127.0.0.1"` by default
+  - tighten `cors_origins` (do not use `"*"` on public infrastructure)
+
+### Bootstrap procedure
+- Obtain a bootstrap peer multiaddr (example placeholder):
+  - `/ip4/<BOOTSTRAP_IP>/tcp/30333/p2p/<BOOTSTRAP_PEER_ID>`
+- Add it to `bootstrap_peers`.
+
+### Quick verification
+- After startup, query head:
+  - `catalyst_head`
+- Query peers:
+  - `catalyst_peerCount`


### PR DESCRIPTION
Closes #162.

### What
- Adds a **public testnet** config template and minimal operator runbook:
  - `crates/catalyst-config/configs/public_testnet.toml`
  - `docs/public_testnet_runbook.md`
- Links these from `README.md`.

### Notes
- Template uses safe-by-default RPC (disabled + loopback bind) and disables mDNS.
- Bootstrap peers are placeholders to be replaced by operators.

### Testing
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
