### PR TITLE
obs: cycle/phase timings + peer/mempool gauges (F3 #164)

### DIFF
--- a/crates/catalyst-cli/src/main.rs
+++ b/crates/catalyst-cli/src/main.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use std::path::PathBuf;
 use std::path::Path;
 use serde::Deserialize;
+use catalyst_utils::metrics::{init_metrics, get_metrics_registry, catalyst_metrics};
 
 mod node;
 mod commands;
@@ -234,6 +235,15 @@ async fn main() -> Result<()> {
 
     // Initialize logging
     init_logging(&cli.log_level, cli.json_logs)?;
+
+    // Initialize metrics registry (best-effort).
+    // This enables consensus/network/storage code to record metrics, even if we only export via logs for now.
+    let _ = init_metrics();
+    if let Some(registry) = get_metrics_registry() {
+        if let Ok(mut reg) = registry.lock() {
+            let _ = catalyst_metrics::register_standard_metrics(&mut reg);
+        }
+    }
 
     info!("Starting Catalyst CLI v{}", env!("CARGO_PKG_VERSION"));
 

--- a/crates/catalyst-consensus/src/consensus.rs
+++ b/crates/catalyst-consensus/src/consensus.rs
@@ -217,10 +217,11 @@ impl CollaborativeConsensus {
         manager: &ProducerManager,
         transactions: Vec<TransactionEntry>,
     ) -> CatalystResult<ProducerQuantity> {
-        log_info!(LogCategory::Consensus, "Starting construction phase");
+        log_info!(LogCategory::Consensus, "Starting construction phase (cycle={})", self.current_cycle);
         
         let phase_timeout = Duration::from_millis(self.config.construction_phase_ms);
         let construction_future = manager.execute_construction_phase(transactions);
+        let t0 = Instant::now();
         
         let quantity = timeout(phase_timeout, construction_future)
             .await
@@ -228,6 +229,7 @@ impl CollaborativeConsensus {
                 phase: "construction".to_string(),
                 duration_ms: self.config.construction_phase_ms,
             })??;
+        observe_histogram!("consensus_phase_duration", t0.elapsed().as_secs_f64());
 
         // Broadcast our quantity
         self.broadcast_message(&quantity).await?;
@@ -241,10 +243,11 @@ impl CollaborativeConsensus {
         manager: &ProducerManager,
         collected_quantities: Vec<ProducerQuantity>,
     ) -> CatalystResult<ProducerCandidate> {
-        log_info!(LogCategory::Consensus, "Starting campaigning phase");
+        log_info!(LogCategory::Consensus, "Starting campaigning phase (cycle={})", self.current_cycle);
 
         let phase_timeout = Duration::from_millis(self.config.campaigning_phase_ms);
         let campaigning_future = manager.execute_campaigning_phase(collected_quantities);
+        let t0 = Instant::now();
         
         let candidate = timeout(phase_timeout, campaigning_future)
             .await
@@ -252,6 +255,7 @@ impl CollaborativeConsensus {
                 phase: "campaigning".to_string(),
                 duration_ms: self.config.campaigning_phase_ms,
             })??;
+        observe_histogram!("consensus_phase_duration", t0.elapsed().as_secs_f64());
 
         // Broadcast our candidate
         self.broadcast_message(&candidate).await?;
@@ -267,10 +271,11 @@ impl CollaborativeConsensus {
         manager: &ProducerManager,
         collected_candidates: Vec<ProducerCandidate>,
     ) -> CatalystResult<ProducerVote> {
-        log_info!(LogCategory::Consensus, "Starting voting phase");
+        log_info!(LogCategory::Consensus, "Starting voting phase (cycle={})", self.current_cycle);
 
         let phase_timeout = Duration::from_millis(self.config.voting_phase_ms);
         let voting_future = manager.execute_voting_phase(collected_candidates);
+        let t0 = Instant::now();
         
         let vote = timeout(phase_timeout, voting_future)
             .await
@@ -278,6 +283,7 @@ impl CollaborativeConsensus {
                 phase: "voting".to_string(),
                 duration_ms: self.config.voting_phase_ms,
             })??;
+        observe_histogram!("consensus_phase_duration", t0.elapsed().as_secs_f64());
 
         // Broadcast our vote
         self.broadcast_message(&vote).await?;
@@ -293,10 +299,11 @@ impl CollaborativeConsensus {
         manager: &ProducerManager,
         collected_votes: Vec<ProducerVote>,
     ) -> CatalystResult<Option<LedgerStateUpdate>> {
-        log_info!(LogCategory::Consensus, "Starting synchronization phase");
+        log_info!(LogCategory::Consensus, "Starting synchronization phase (cycle={})", self.current_cycle);
 
         let phase_timeout = Duration::from_millis(self.config.synchronization_phase_ms);
         let sync_future = manager.execute_synchronization_phase(collected_votes);
+        let t0 = Instant::now();
         
         let output = timeout(phase_timeout, sync_future)
             .await
@@ -304,6 +311,7 @@ impl CollaborativeConsensus {
                 phase: "synchronization".to_string(),
                 duration_ms: self.config.synchronization_phase_ms,
             })??;
+        observe_histogram!("consensus_phase_duration", t0.elapsed().as_secs_f64());
 
         // Broadcast our output
         self.broadcast_message(&output).await?;


### PR DESCRIPTION
Closes #164.

### What
- Adds basic public-testnet observability (logs + metrics registry):
  - Initializes the `catalyst-utils` metrics registry in the CLI.
  - Records **per-phase durations** (`consensus_phase_duration`) inside the consensus engine.
  - Adds a periodic node-side log line (`OBS ...`) and updates gauges for:
    - `network_peers_connected`
    - `mempool_size`
  - Improves LSU rejection logs to include cycle/CID + expected root + mismatch details.

### Testing
- `cargo test -p catalyst-cli -p catalyst-consensus`
- `make testnet-down && make testnet-up && make testnet-status && make testnet-contract-test && make testnet-down`
