### PR TITLE
docs: add public testnet operator and user guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Catalyst Docs
+
+These docs are written against the current `catalyst-node-rust` implementation (CLI: `catalyst-cli`).
+
+## Guides
+
+- **Node operators**: [`node-operator-guide.md`](./node-operator-guide.md)
+  - Build + run a local node
+  - Build + run a 3-node public testnet (Vultr-style) with EU as boot + RPC
+  - Firewall ports and common pitfalls
+
+- **Users**: [`user-guide.md`](./user-guide.md)
+  - Using the dev/test faucet
+  - Sending a simple payment transaction
+  - Deploying + calling an EVM contract (REVM-backed)
+
+- **Testers**: [`tester-guide.md`](./tester-guide.md)
+  - Health checks (status/head advancing)
+  - RPC checks, peer checks, and basic troubleshooting
+
+- **Builders**: [`builder-guide.md`](./builder-guide.md)
+  - RPC methods currently implemented
+  - Contract/runtime notes and current limitations
+
+## Important implementation notes (current state)
+
+- **Consensus traffic is P2P on `30333/tcp`**, not RPC. RPC is only for client interaction.
+- **Faucet** is *not* an ERC20 contract. It’s a deterministic, pre-funded account used for dev/test flows.
+- **Tokenomics / fees** are currently minimal scaffolding (see Builder guide).
+

--- a/docs/builder-guide.md
+++ b/docs/builder-guide.md
@@ -1,0 +1,85 @@
+# Builder guide (RPC surface, integration notes, current limitations)
+
+This guide is for developers integrating with the current testnet implementation.
+
+## Architecture (current)
+
+- **P2P (`30333/tcp`)**: consensus + transaction gossip between nodes
+- **RPC (`8545/tcp`)**: HTTP JSON-RPC for clients (submit tx, query balances/head, EVM helpers)
+
+Consensus traffic is not carried over RPC.
+
+## RPC methods implemented (as of `catalyst-rpc/0.1.0`)
+
+Core:
+- `catalyst_version`
+- `catalyst_peerCount`
+- `catalyst_head`
+- `catalyst_blockNumber` (mapped to applied cycle)
+
+Accounts:
+- `catalyst_getBalance` (returns decimal string)
+- `catalyst_getBalanceProof` (balance + state root + Merkle proof steps)
+- `catalyst_getNonce`
+
+Tx submission:
+- `catalyst_sendRawTransaction`
+  - payload is **hex-encoded bincode(Transaction)** (dev transport)
+  - returns a `tx_id` (sha256 over tx bytes)
+
+EVM helpers (dev/test):
+- `catalyst_getCode` (20-byte address)
+- `catalyst_getLastReturn` (20-byte address)
+- `catalyst_getStorageAt` (20-byte address, 32-byte slot)
+
+## Transaction model (current)
+
+The CLI constructs `catalyst_core::protocol::Transaction` objects and submits them as bincode bytes.
+
+Important behavior:
+- RPC verifies Schnorr signature and rejects “nonce too low”.
+- Inclusion happens via validator consensus cycles; acceptance at RPC does not guarantee immediate inclusion.
+
+## Faucet model (dev/test)
+
+The faucet is a deterministic, pre-funded account initialized by the node:
+- private key bytes are `[0xFA; 32]`
+- initial balance is `1_000_000` (if missing in state)
+
+This is *not* a contract faucet (no ERC20, no mint function).
+
+## EVM execution (current)
+
+The node applies EVM deploy/call during LSU application using REVM and persists:
+- runtime code at `evm:code:<addr20>` (enables `catalyst_getCode`)
+- storage slots at `evm:storage:<addr20><slot>`
+- last return data at `evm:last_return:<addr20>` (enables `catalyst_getLastReturn`)
+
+### Practical tip: use a fresh funded key for EVM
+
+In the current implementation, EVM tx nonce is derived from the **protocol nonce**.
+If you send multiple “payment” txs from the faucet key and then try EVM deploys from the same key,
+you can hit nonce mismatches. The recommended workflow is:
+
+1) create a fresh wallet key
+2) fund it from the faucet
+3) deploy/call using the fresh wallet key
+
+See [`user-guide.md`](./user-guide.md).
+
+## Tokenomics / fees (current)
+
+Current behavior is scaffolding-oriented:
+- balances are integer values stored under `bal:<pubkey>`
+- transfers are validated with a simple “no negative balances” rule
+- transaction `fees` are set to `0` in the CLI
+- EVM executes with `gas_price = 0` (no fee charging yet)
+
+There is no implemented issuance schedule, staking rewards, inflation, or burn mechanics in this repo snapshot.
+
+## Known limitations
+
+- RPC does not currently return rich transaction/block data (e.g. `getTransactionByHash` returns `None`).
+- RPC peer count reflects the RPC node’s current network connections; it is not always a full picture of the validator mesh.
+- Logging config includes a `file_path`, but the node primarily logs to stdout/stderr via `tracing` in the current setup.
+

--- a/docs/tester-guide.md
+++ b/docs/tester-guide.md
@@ -1,0 +1,76 @@
+# Tester guide (health checks + troubleshooting)
+
+This guide focuses on black-box testing a running network via RPC and basic node logs.
+
+## Health checks
+
+### 1) Head advances
+
+Run twice (a few cycles apart):
+
+```bash
+./target/release/catalyst-cli status --rpc-url http://<RPC_HOST>:8545
+sleep 30
+./target/release/catalyst-cli status --rpc-url http://<RPC_HOST>:8545
+```
+
+Expected:
+- `applied_cycle` increases
+- `applied_lsu_hash` / `last_lsu_cid` often change
+
+### 2) Peer count (best-effort)
+
+```bash
+./target/release/catalyst-cli peers --rpc-url http://<RPC_HOST>:8545
+```
+
+Notes:
+- `peer_count` is useful for diagnosing connectivity, but it is not the primary liveness signal.
+- A network can be live even if the RPC node’s `peer_count` is low (depending on topology).
+
+### 3) Basic payment test
+
+See [`user-guide.md`](./user-guide.md) for the exact faucet/payment steps.
+
+## Common failure modes
+
+### “Insufficient data collected: got 1, required 2”
+
+Meaning: a validator did not collect enough peer inputs to reach required majority for a cycle.
+
+Checklist:
+- **Firewall**: ensure `30333/tcp` is open inbound on all nodes.
+- **Process**: ensure node is listening on `0.0.0.0:30333`.
+- **Bootstrap peers**: ensure nodes list each other under `[network].bootstrap_peers`.
+- **Clock drift**: cycles are epoch-aligned; ensure NTP/chrony is active.
+
+### Transactions accepted but not applied (balance doesn’t change)
+
+Meaning: the RPC accepted the tx, but it didn’t make it into an applied LSU yet.
+
+Checklist:
+- Wait a few cycles (propagation + leader selection).
+- Ensure the RPC node is connected to the validator mesh (`peers`).
+- Validate the sender is funded (faucet balance > 0).
+
+## Firewall / network debugging commands
+
+### UFW
+
+```bash
+sudo ufw status numbered
+sudo journalctl -k --since "10 minutes ago" | grep -i "UFW BLOCK" | tail -n 50 || true
+```
+
+### Listening ports
+
+```bash
+sudo ss -ltnp | egrep ':30333|:8545' || true
+```
+
+### Connectivity
+
+```bash
+nc -vz <NODE_PUBLIC_IP> 30333
+```
+

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,134 @@
+# User guide (faucet, payments, deploy + call)
+
+This guide assumes there is a reachable RPC endpoint, e.g.:
+
+- `RPC_URL=http://<EU_PUBLIC_IP>:8545`
+- Example: `RPC_URL=http://45.32.177.248:8545`
+
+All commands below are client-side; you can run them from your laptop/desktop.
+
+## 1) Faucet (dev/test implementation)
+
+In the current implementation, the faucet is **not** an ERC20 contract.
+
+It is a deterministic, pre-funded account:
+- faucet private key bytes are `[0xFA; 32]`
+- on node startup, if missing from state, it is initialized with balance `1_000_000`
+
+Create the faucet key file (exactly 64 hex chars; no `0x` prefix needed):
+
+```bash
+python3 -c 'print("fa"*32)' > faucet.key
+```
+
+Derive faucet pubkey:
+
+```bash
+FAUCET_PK="$(./target/release/catalyst-cli pubkey --key-file faucet.key | tail -n 1)"
+echo "FAUCET_PK=$FAUCET_PK"
+```
+
+Confirm faucet is funded:
+
+```bash
+./target/release/catalyst-cli balance "$FAUCET_PK" --rpc-url "$RPC_URL"
+```
+
+## 2) Send a simple payment transaction
+
+Recipient addresses in this scaffold are **32-byte hex pubkeys** (node IDs).
+
+Example:
+
+```bash
+RECIP="<RECIPIENT_PUBKEY_HEX>"
+./target/release/catalyst-cli send "$RECIP" 3 --key-file faucet.key --rpc-url "$RPC_URL"
+sleep 60
+./target/release/catalyst-cli balance "$RECIP" --rpc-url "$RPC_URL"
+```
+
+Notes:
+- `send` returning a `tx_id` means the RPC accepted the transaction. Inclusion can take a few cycles.
+
+## 3) Deploy + call an EVM contract (REVM-backed)
+
+This repo ships a deterministic initcode fixture at:
+- `testdata/evm/return_2a_initcode.hex`
+
+It deploys a contract whose runtime bytecode returns `0x2a` (42) on empty calldata.
+
+### Use a fresh wallet for EVM
+
+If you used the faucet key to send payments first, EVM deploys from that same key can fail due to nonce interactions.
+Recommended workflow:
+
+1) Generate a fresh wallet key
+2) Fund it from the faucet
+3) Deploy + call using the fresh wallet key
+
+Create a new wallet key:
+
+```bash
+python3 -c 'import os,binascii; print(binascii.hexlify(os.urandom(32)).decode())' > evm_wallet.key
+EVM_PK="$(./target/release/catalyst-cli pubkey --key-file evm_wallet.key | tail -n 1)"
+echo "EVM_PK=$EVM_PK"
+```
+
+Fund it:
+
+```bash
+./target/release/catalyst-cli send "$EVM_PK" 100 --key-file faucet.key --rpc-url "$RPC_URL"
+sleep 60
+./target/release/catalyst-cli balance "$EVM_PK" --rpc-url "$RPC_URL"
+```
+
+### Deploy
+
+```bash
+./target/release/catalyst-cli deploy testdata/evm/return_2a_initcode.hex \
+  --key-file evm_wallet.key --rpc-url "$RPC_URL" --runtime evm
+```
+
+Copy the printed `contract_address` to `ADDR`.
+
+Wait for code to appear:
+
+```bash
+ADDR="0x<PASTE_CONTRACT_ADDRESS>"
+
+while true; do
+  code=$(curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"catalyst_getCode\",\"params\":[\"$ADDR\"]}" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("result",""))')
+  echo "code=$code"
+  [ "$code" != "0x" ] && break
+  sleep 5
+done
+```
+
+### Call
+
+Empty calldata:
+
+```bash
+./target/release/catalyst-cli call "$ADDR" 0x \
+  --key-file evm_wallet.key --rpc-url "$RPC_URL" --value 0
+```
+
+Poll the persisted return value:
+
+```bash
+while true; do
+  ret=$(curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"catalyst_getLastReturn\",\"params\":[\"$ADDR\"]}" \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin).get("result",""))')
+  echo "ret=$ret"
+  [ "$ret" != "0x" ] && break
+  sleep 5
+done
+```
+
+Expected:
+
+`0x000000000000000000000000000000000000000000000000000000000000002a`
+


### PR DESCRIPTION
Adds guides for node operators, users, testers, and builders, including a working 3-node public testnet example and faucet/payment + EVM deploy/call walkthroughs.