### PR TITLE
p2p: compute peer count from live peer set

### DIFF
--- a/crates/catalyst-network/src/service.rs
+++ b/crates/catalyst-network/src/service.rs
@@ -344,7 +344,10 @@ impl NetworkService {
     }
 
     pub async fn get_stats(&self) -> NetworkStats {
-        self.stats.read().await.clone()
+        // Stats are best-effort; ensure peer count reflects live peer set even when idle.
+        let mut st = self.stats.read().await.clone();
+        st.connected_peers = self.peers.read().await.len();
+        st
     }
 
     pub async fn broadcast_envelope(&self, envelope: &MessageEnvelope) -> NetworkResult<()> {


### PR DESCRIPTION
Make NetworkService::get_stats override connected_peers from the live peer set to avoid stale peerCount reporting when the network is idle.