### PR TITLE
p2p: add DNS TXT seeds for bootstrap peers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node.key
 /testnet/
 /scripts/.cache/
 **/*.pid
+/txgen/
 
 # Local storage / rocksdb data (never commit)
 /crates/catalyst-storage/catalyst_data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "dirs",
  "futures",
  "hex",
+ "hickory-resolver 0.25.2",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -1964,6 +1965,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -3085,6 +3092,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring 0.17.14",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,7 +3124,7 @@ checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "ipconfig",
  "lru-cache",
  "once_cell",
@@ -3101,6 +3133,27 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto 0.25.2",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -4074,7 +4127,7 @@ checksum = "d17cbcf7160ff35c3e8e560de4a068fe9d6cb777ea72840e48eb76ff9576c4b6"
 dependencies = [
  "async-trait",
  "futures",
- "hickory-resolver",
+ "hickory-resolver 0.24.4",
  "libp2p-core",
  "libp2p-identity",
  "parking_lot",
@@ -4191,7 +4244,7 @@ checksum = "49007d9a339b3e1d7eeebc4d67c05dbf23d300b7d091193ec2d3f26802d7faf2"
 dependencies = [
  "data-encoding",
  "futures",
- "hickory-proto",
+ "hickory-proto 0.24.4",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -4666,6 +4719,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5109,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -7333,6 +7407,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/crates/catalyst-cli/Cargo.toml
+++ b/crates/catalyst-cli/Cargo.toml
@@ -52,6 +52,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"] }
 http-body-util = "0.1.3"
 bytes = "1.11.1"
 tokio-util = { workspace = true, features = ["io"] }
+hickory-resolver = "0.25.2"
 
 [features]
 default = []

--- a/crates/catalyst-cli/src/config.rs
+++ b/crates/catalyst-cli/src/config.rs
@@ -69,6 +69,16 @@ pub struct NetworkConfig {
     
     /// Bootstrap peer addresses
     pub bootstrap_peers: Vec<String>,
+
+    /// Optional DNS seed domains (TXT/A/AAAA) used to discover bootstrap peers at runtime.
+    ///
+    /// TXT records may contain multiaddrs (preferred), IPs, or host:port entries.
+    /// Example TXT values:
+    /// - `/ip4/45.32.177.248/tcp/30333`
+    /// - `45.32.177.248:30333`
+    /// - `45.32.177.248`
+    #[serde(default)]
+    pub dns_seeds: Vec<String>,
     
     /// Maximum number of peers to connect to
     pub max_peers: u32,
@@ -355,6 +365,7 @@ impl Default for NodeConfig {
                     "/ip6/::/tcp/30333".to_string(),
                 ],
                 bootstrap_peers: vec![],
+                dns_seeds: vec![],
                 max_peers: 50,
                 min_peers: 5,
                 protocol_version: "catalyst/1.0".to_string(),

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,3 +54,23 @@ make devnet-up HOST=<public_ip_or_dns> P2P_PORT=30333 RPC_PORT=8545
 make devnet-status
 make devnet-down
 ```
+
+## `txgen_faucet.sh`
+
+Generates a small, random number of faucet-funded transfers per block so
+blocks don’t look empty (useful for public testnets + explorers).
+
+Run:
+
+```bash
+RPC_URL="http://<your-rpc-host>:8545" bash scripts/txgen_faucet.sh
+```
+
+Safety knobs (environment variables):
+- `MAX_TX_PER_BLOCK` (default `2`): each new block sends 0..MAX tiny transfers
+- `AMOUNT_MIN` / `AMOUNT_MAX` (defaults `1`..`3`)
+- `RECIP_COUNT` (default `25`): size of recipient pool
+- `STOP_AFTER_BLOCKS` (unset => run forever)
+
+State:
+- stores `faucet.key` + recipient pool under `./txgen/` by default (override with `STATE_DIR`)

--- a/scripts/txgen_faucet.sh
+++ b/scripts/txgen_faucet.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# txgen_faucet.sh
+#
+# Generates a small, random number of faucet-funded transfers per block so
+# blocks don’t look empty.
+#
+# Designed for public testnets: runs against a single RPC endpoint and relies
+# on the network to propagate txs to the deterministic batch leader.
+#
+# Safety: keep MAX_TX_PER_BLOCK and AMOUNT_MAX low so you don’t drain faucet.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RPC_URL="${RPC_URL:-http://127.0.0.1:8545}"
+BIN="${BIN:-${CARGO_TARGET_DIR:-$ROOT_DIR/target}/release/catalyst-cli}"
+
+STATE_DIR="${STATE_DIR:-$ROOT_DIR/txgen}"
+FAUCET_KEY_FILE="${FAUCET_KEY_FILE:-$STATE_DIR/faucet.key}"
+RECIPS_FILE="${RECIPS_FILE:-$STATE_DIR/recipients.txt}"
+
+RECIP_COUNT="${RECIP_COUNT:-25}"
+MAX_TX_PER_BLOCK="${MAX_TX_PER_BLOCK:-2}"   # 0..MAX per block
+AMOUNT_MIN="${AMOUNT_MIN:-1}"
+AMOUNT_MAX="${AMOUNT_MAX:-3}"
+POLL_SECS="${POLL_SECS:-2}"
+JITTER_MS_MAX="${JITTER_MS_MAX:-600}"       # delay between txs in a block
+
+# Optional: stop after N blocks (unset => run forever)
+STOP_AFTER_BLOCKS="${STOP_AFTER_BLOCKS:-}"
+
+need_bin() {
+  if [ ! -x "$BIN" ]; then
+    echo "ERROR: catalyst-cli not found/executable at BIN=$BIN"
+    echo "Build it with: cargo build --release -p catalyst-cli"
+    exit 1
+  fi
+}
+
+rpc_applied_cycle() {
+  # NOTE: do NOT use `python3 - <<EOF` in a pipeline: that consumes stdin for the program,
+  # causing `curl` to error with "failed writing body" (exit 23) under `pipefail`.
+  local body
+  body="$(curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"catalyst_getSyncInfo","params":[]}' 2>/dev/null || true)"
+  python3 -c 'import sys, json
+try:
+  obj = json.load(sys.stdin)
+  head = (obj.get("result") or {}).get("head") or {}
+  print(int(head.get("applied_cycle", 0)))
+except Exception:
+  print(0)
+' <<<"$body" 2>/dev/null || echo 0
+}
+
+ensure_state() {
+  mkdir -p "$STATE_DIR"
+  if [ ! -f "$FAUCET_KEY_FILE" ]; then
+    # Dev-only deterministic faucet key (matches node genesis logic)
+    python3 -c 'print("fa"*32)' > "$FAUCET_KEY_FILE"
+  fi
+
+  if [ ! -f "$RECIPS_FILE" ]; then
+    : > "$RECIPS_FILE"
+  fi
+
+  # Ensure we have at least RECIP_COUNT recipients. Each line is a 32-byte pubkey hex.
+  local cur
+  cur="$(grep -c '^[0-9a-f]\{64\}$' "$RECIPS_FILE" 2>/dev/null || true)"
+  if [ "${cur}" -lt "${RECIP_COUNT}" ]; then
+    local to_make=$((RECIP_COUNT - cur))
+    for _ in $(seq 1 "$to_make"); do
+      # We only need pubkeys; recipients never sign.
+      # Generate a random 32-byte key file and derive its pubkey.
+      local kf="$STATE_DIR/recip_$(date +%s%N)_$RANDOM.key"
+      python3 -c 'import os,binascii; print(binascii.hexlify(os.urandom(32)).decode())' > "$kf"
+      "$BIN" --log-level error pubkey --key-file "$kf" | tail -n 1 >> "$RECIPS_FILE"
+      rm -f "$kf" || true
+    done
+  fi
+}
+
+rand_int() {
+  # inclusive range [lo, hi]
+  local lo="$1"
+  local hi="$2"
+  if [ "$hi" -lt "$lo" ]; then
+    echo "$lo"
+    return
+  fi
+  local span=$((hi - lo + 1))
+  echo $((lo + (RANDOM % span)))
+}
+
+pick_recipient() {
+  # pick a random line from recipients file (only valid 64-hex lines)
+  local idx
+  idx="$(rand_int 1 "$RECIP_COUNT")"
+  awk 'BEGIN{n=0} /^[0-9a-f]{64}$/ {n++; if(n=='"$idx"'){print; exit}}' "$RECIPS_FILE"
+}
+
+send_one() {
+  local to_pk="$1"
+  local amt="$2"
+  local out
+  out="$("$BIN" send "$to_pk" "$amt" --key-file "$FAUCET_KEY_FILE" --rpc-url "$RPC_URL" 2>/dev/null || true)"
+  local txid
+  txid="$(printf "%s\n" "$out" | awk '/tx_id:/ {print $2}' | tail -n 1)"
+  if [ -z "$txid" ]; then
+    echo "WARN: send failed (amt=$amt to=$to_pk). Output:"
+    printf "%s\n" "$out" | tail -n 20 || true
+    return 1
+  fi
+  echo "$txid"
+}
+
+main() {
+  need_bin
+  ensure_state
+
+  echo "==> txgen: RPC_URL=$RPC_URL"
+  echo "==> txgen: MAX_TX_PER_BLOCK=$MAX_TX_PER_BLOCK AMOUNT_RANGE=[$AMOUNT_MIN,$AMOUNT_MAX] RECIP_COUNT=$RECIP_COUNT"
+  echo "==> txgen: state dir: $STATE_DIR"
+  echo "==> txgen: faucet key: $FAUCET_KEY_FILE"
+  echo "==> txgen: recipients: $RECIPS_FILE"
+
+  local last
+  last="$(rpc_applied_cycle)"
+  echo "==> txgen: starting at applied_cycle=$last"
+
+  local blocks=0
+  while true; do
+    local cur
+    cur="$(rpc_applied_cycle)"
+    if [ "$cur" -le "$last" ]; then
+      sleep "$POLL_SECS"
+      continue
+    fi
+
+    last="$cur"
+    blocks=$((blocks + 1))
+
+    local n
+    n="$(rand_int 0 "$MAX_TX_PER_BLOCK")"
+    if [ "$n" -eq 0 ]; then
+      echo "cycle=$cur txs=0"
+    else
+      echo "cycle=$cur txs=$n"
+    fi
+
+    for _ in $(seq 1 "$n"); do
+      local to_pk amt txid
+      to_pk="$(pick_recipient)"
+      amt="$(rand_int "$AMOUNT_MIN" "$AMOUNT_MAX")"
+      txid="$(send_one "$to_pk" "$amt" || true)"
+      if [ -n "$txid" ]; then
+        echo "  sent tx_id=$txid amount=$amt to=$to_pk"
+      fi
+      # jitter to avoid sending all txs at same instant
+      local jms
+      jms="$(rand_int 0 "$JITTER_MS_MAX")"
+      python3 - <<PY
+import time
+time.sleep(${jms}/1000.0)
+PY
+    done
+
+    if [ -n "$STOP_AFTER_BLOCKS" ] && [ "$blocks" -ge "$STOP_AFTER_BLOCKS" ]; then
+      echo "==> txgen: stopping after $blocks blocks"
+      break
+    fi
+  done
+}
+
+main "$@"
+


### PR DESCRIPTION
Adds `network.dns_seeds` which resolves TXT (preferred) or A/AAAA records into bootstrap multiaddrs and periodically refreshes them so IPs can rotate without restarts.

Also adds a small `txgen_faucet.sh` helper and ignores local `./txgen/` state.