### PR TITLE
protocol: make faucet genesis configurable

### DIFF
--- a/docs/builder-guide.md
+++ b/docs/builder-guide.md
@@ -67,9 +67,13 @@ For external wallets/integrators, see [`wallet-interop.md`](./wallet-interop.md)
 
 ## Faucet model (dev/test)
 
-The faucet is a deterministic, pre-funded account initialized by the node:
-- private key bytes are `[0xFA; 32]`
-- initial balance is `1_000_000` (if missing in state)
+The node supports an optional faucet account seeded at genesis for dev/test usage:
+- **dev/local default**: deterministic faucet key (`[0xFA; 32]`) with a configurable initial balance
+- **public networks**: disable the deterministic faucet and configure a real faucet/treasury pubkey
+  and large initial balance in `protocol.*` config
+
+The deterministic faucet key is **public** (embedded in the repo), so it must not be used as the
+funding source for any long-lived public network.
 
 This is *not* a contract faucet (no ERC20, no mint function).
 

--- a/docs/node-operator-guide.md
+++ b/docs/node-operator-guide.md
@@ -27,6 +27,42 @@ network_id = "catalyst-testnet"
 Important:
 - **Do not change** these values for a running network. Changing them creates a **new chain**.
 
+## Faucet genesis funding (dev vs public testnet)
+
+This node can optionally seed a faucet/treasury account at genesis (fresh DB only). For **local/dev**
+networks you can use the deterministic faucet key, but for any **public** testnet you must configure
+a real pubkey and disable the deterministic faucet.
+
+### Local/dev (default)
+
+```toml
+[protocol]
+chain_id = 31337
+network_id = "local"
+faucet_mode = "deterministic"
+allow_deterministic_faucet = true
+faucet_balance = 1000000
+```
+
+### Public testnet (recommended)
+
+Pick a private treasury key (never publish it), derive its 32-byte pubkey hex, then configure:
+
+```toml
+[protocol]
+chain_id = 200820092
+network_id = "catalyst-testnet"
+faucet_mode = "configured"
+allow_deterministic_faucet = false
+faucet_pubkey_hex = "0x<32-byte-pubkey-hex>"
+faucet_balance = 1000000000000
+```
+
+Notes:
+- `faucet_balance` is an `i64`; choose a very large value for long-lived testnets.
+- Your public faucet web app/service should spend from a **hot wallet**, topped up from this
+  treasury pubkey as needed.
+
 ## Build
 
 From the repo root:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -22,9 +22,22 @@ Check `network_id` and `chain_id` match what operators published (see [`network-
 
 In the current implementation, the faucet is **not** an ERC20 contract.
 
-It is a deterministic, pre-funded account:
+### Local/dev convenience faucet
+
+For local developer networks, the node can optionally initialize a deterministic, pre-funded faucet
+account at genesis:
 - faucet private key bytes are `[0xFA; 32]`
-- on node startup, if missing from state, it is initialized with balance `1_000_000`
+- on fresh DB startup, if missing from state, it is initialized with `protocol.faucet_balance` (default `1_000_000`)
+
+Important:
+- This deterministic key is **public** (it is embedded in the repo). Do **not** rely on it for public testnets.
+
+### Public testnet faucet
+
+For a long-lived public testnet, operators should disable the deterministic faucet and configure a
+real faucet/treasury pubkey in `config.toml` (`protocol.faucet_mode = "configured"`). The public
+faucet web app/service should distribute from a **separate hot wallet** that is periodically topped
+up by the private treasury key.
 
 Create the faucet key file (exactly 64 hex chars; no `0x` prefix needed):
 


### PR DESCRIPTION
Add protocol options to disable the public deterministic faucet key and instead seed a configured faucet/treasury pubkey with a large balance on fresh genesis. Update docs to distinguish local/dev vs public testnet behavior.

Refs #220.