### PR TITLE
p2p: harden WAN joins with dial backoff and rebroadcast

### DIFF
--- a/crates/catalyst-network/src/simple.rs
+++ b/crates/catalyst-network/src/simple.rs
@@ -12,11 +12,13 @@ use crate::config::NetworkConfig;
 use crate::error::{NetworkError, NetworkResult};
 
 use catalyst_utils::logging::*;
-use catalyst_utils::network::MessageEnvelope;
+use catalyst_utils::network::{
+    decode_envelope_wire, encode_envelope_wire, EnvelopeWireError, MessageEnvelope, RoutingInfo,
+};
 
 use futures::{SinkExt, StreamExt};
 use libp2p::Multiaddr;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
@@ -71,17 +73,27 @@ pub struct NetworkService {
     stats: Arc<RwLock<NetworkStats>>,
     event_tx: Arc<RwLock<Vec<mpsc::UnboundedSender<NetworkEvent>>>>,
     tasks: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+    local_id: String,
+    seen: Arc<Mutex<HashMap<String, std::time::Instant>>>,
 }
 
 impl NetworkService {
     pub async fn new(config: NetworkConfig) -> NetworkResult<Self> {
         config.validate()?;
+        let local_id = config
+            .peer
+            .listen_addresses
+            .get(0)
+            .map(|a| a.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
         Ok(Self {
             config,
             peers: Arc::new(Mutex::new(HashMap::new())),
             stats: Arc::new(RwLock::new(NetworkStats::default())),
             event_tx: Arc::new(RwLock::new(Vec::new())),
             tasks: Arc::new(Mutex::new(Vec::new())),
+            local_id,
+            seen: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -115,28 +127,12 @@ impl NetworkService {
             self.tasks.lock().await.push(handle);
         }
 
-        // Dial bootstrap peers (best-effort).
-        for (_peer_id, addr) in &self.config.peer.bootstrap_peers {
-            if let Some(socket) = multiaddr_to_socketaddr(addr) {
-                let svc = self.clone();
-                let handle = tokio::spawn(async move {
-                    match TcpStream::connect(socket).await {
-                        Ok(stream) => {
-                            let _ = svc.emit(NetworkEvent::PeerConnected { addr: socket }).await;
-                            svc.spawn_connection(socket, stream).await;
-                        }
-                        Err(e) => {
-                            let _ = svc.emit(NetworkEvent::Error {
-                                error: NetworkError::Timeout { duration: std::time::Duration::from_secs(0) },
-                            })
-                            .await;
-                            log_warn!(LogCategory::Network, "Failed to connect to bootstrap {}: {}", socket, e);
-                        }
-                    }
-                });
-                self.tasks.lock().await.push(handle);
-            }
-        }
+        // Dial bootstrap peers with retry/backoff/jitter until we meet `min_peers`.
+        let svc = self.clone();
+        let handle = tokio::spawn(async move {
+            svc.bootstrap_dial_loop().await;
+        });
+        self.tasks.lock().await.push(handle);
 
         Ok(())
     }
@@ -180,7 +176,7 @@ impl NetworkService {
     /// Broadcast a message envelope to all connected peers.
     pub async fn broadcast_envelope(&self, envelope: &MessageEnvelope) -> NetworkResult<()> {
         let bytes =
-            bincode::serialize(envelope).map_err(|e| NetworkError::SerializationFailed(e.to_string()))?;
+            encode_envelope_wire(envelope).map_err(|e| NetworkError::SerializationFailed(e.to_string()))?;
 
         let peers = self.peers.lock().await;
         for (_addr, tx) in peers.iter() {
@@ -197,6 +193,9 @@ impl NetworkService {
         let peers = self.peers.clone();
         let stats = self.stats.clone();
         let svc = self.clone();
+        let local_id = self.local_id.clone();
+        let seen = self.seen.clone();
+        let dedup_window = self.config.gossip.duplicate_detection_window;
 
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<Vec<u8>>();
         {
@@ -231,10 +230,30 @@ impl NetworkService {
                 if !budget.allow(now, bytes.len()) {
                     continue;
                 }
-                let env: MessageEnvelope = match bincode::deserialize(&bytes) {
+                let env: MessageEnvelope = match decode_envelope_wire(&bytes) {
                     Ok(e) => e,
+                    Err(EnvelopeWireError::UnsupportedVersion { got, local }) => {
+                        log_warn!(
+                            LogCategory::Network,
+                            "Dropping frame from {} due to unsupported envelope version (got={} local={})",
+                            peer_addr,
+                            got,
+                            local
+                        );
+                        continue;
+                    }
                     Err(_) => continue,
                 };
+
+                // Dedup by envelope id within a sliding window.
+                {
+                    let mut s = seen.lock().await;
+                    s.retain(|_, t| now.duration_since(*t) <= dedup_window);
+                    if s.contains_key(&env.id) {
+                        continue;
+                    }
+                    s.insert(env.id.clone(), now);
+                }
 
                 {
                     let mut st = stats.write().await;
@@ -243,10 +262,28 @@ impl NetworkService {
 
                 let _ = svc
                     .emit(NetworkEvent::MessageReceived {
-                        envelope: env,
+                        envelope: env.clone(),
                         from: peer_addr,
                     })
                     .await;
+
+                // Multi-hop rebroadcast: forward broadcast envelopes to all peers except sender
+                // with hop/loop limits.
+                if env.target.is_none() && should_forward(&env, &local_id) {
+                    if let Some(fwd) = forwarded(env, &local_id) {
+                        let bytes = match encode_envelope_wire(&fwd) {
+                            Ok(b) => b,
+                            Err(_) => continue,
+                        };
+                        let peers = peers.lock().await;
+                        for (addr, tx) in peers.iter() {
+                            if *addr == peer_addr {
+                                continue;
+                            }
+                            let _ = tx.send(bytes.clone());
+                        }
+                    }
+                }
             }
 
             {
@@ -260,6 +297,78 @@ impl NetworkService {
 
         self.tasks.lock().await.push(writer);
         self.tasks.lock().await.push(reader);
+    }
+
+    async fn bootstrap_dial_loop(&self) {
+        let bootstrap: Vec<SocketAddr> = self
+            .config
+            .peer
+            .bootstrap_peers
+            .iter()
+            .filter_map(|(_peer_id, addr)| multiaddr_to_socketaddr(addr))
+            .collect();
+
+        if bootstrap.is_empty() {
+            return;
+        }
+
+        let mut backoff: HashMap<SocketAddr, (u32, std::time::Instant)> = HashMap::new();
+        let mut incompatible: HashSet<SocketAddr> = HashSet::new();
+
+        let base = self.config.peer.retry_backoff;
+        let max_attempts = self.config.peer.max_retry_attempts;
+        let mut tick = tokio::time::interval(self.config.discovery.bootstrap_interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tick.tick().await;
+
+            let connected = self.peers.lock().await.len();
+            if connected >= self.config.peer.min_peers {
+                continue;
+            }
+
+            for addr in &bootstrap {
+                if incompatible.contains(addr) {
+                    continue;
+                }
+
+                let now = std::time::Instant::now();
+                let (attempts, next_at) = backoff.get(addr).cloned().unwrap_or((0, now));
+                if now < next_at {
+                    continue;
+                }
+                if max_attempts > 0 && attempts >= max_attempts {
+                    continue;
+                }
+
+                let socket = *addr;
+                let svc = self.clone();
+                let attempts_next = attempts.saturating_add(1);
+                let delay = compute_backoff(base, attempts_next).unwrap_or(base);
+                let jitter = jitter_ms(socket, attempts_next);
+                backoff.insert(
+                    *addr,
+                    (
+                        attempts_next,
+                        now + delay + std::time::Duration::from_millis(jitter),
+                    ),
+                );
+
+                let handle = tokio::spawn(async move {
+                    match TcpStream::connect(socket).await {
+                        Ok(stream) => {
+                            let _ = svc.emit(NetworkEvent::PeerConnected { addr: socket }).await;
+                            svc.spawn_connection(socket, stream).await;
+                        }
+                        Err(e) => {
+                            log_warn!(LogCategory::Network, "bootstrap dial failed {}: {}", socket, e);
+                        }
+                    }
+                });
+                self.tasks.lock().await.push(handle);
+            }
+        }
     }
 
     async fn emit(&self, event: NetworkEvent) -> NetworkResult<()> {
@@ -279,8 +388,60 @@ impl Clone for NetworkService {
             stats: self.stats.clone(),
             event_tx: self.event_tx.clone(),
             tasks: self.tasks.clone(),
+            local_id: self.local_id.clone(),
+            seen: self.seen.clone(),
         }
     }
+}
+
+fn should_forward(env: &MessageEnvelope, local_id: &str) -> bool {
+    if env.is_expired() {
+        return false;
+    }
+    if let Some(r) = &env.routing_info {
+        if r.hop_count >= r.max_hops {
+            return false;
+        }
+        if r.visited_nodes.iter().any(|v| v == local_id) {
+            return false;
+        }
+    }
+    true
+}
+
+fn forwarded(mut env: MessageEnvelope, local_id: &str) -> Option<MessageEnvelope> {
+    if env.is_expired() {
+        return None;
+    }
+    let mut r = env.routing_info.take().unwrap_or_else(|| RoutingInfo::new(10));
+    if r.hop_count >= r.max_hops {
+        return None;
+    }
+    if r.visited_nodes.iter().any(|v| v == local_id) {
+        return None;
+    }
+    r.visited_nodes.push(local_id.to_string());
+    r.hop_count = r.hop_count.saturating_add(1);
+    env.routing_info = Some(r);
+    Some(env)
+}
+
+fn compute_backoff(base: std::time::Duration, attempts: u32) -> Option<std::time::Duration> {
+    // base * 2^(attempts-1), clamped to 60s
+    let pow = attempts.saturating_sub(1).min(10); // 2^10 = 1024x
+    let mult = 1u64.checked_shl(pow)?;
+    let ms = base.as_millis().saturating_mul(mult as u128);
+    let ms = ms.min(60_000);
+    Some(std::time::Duration::from_millis(ms as u64))
+}
+
+fn jitter_ms(addr: SocketAddr, attempts: u32) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    addr.hash(&mut h);
+    attempts.hash(&mut h);
+    let v = h.finish();
+    (v % 250) as u64
 }
 
 fn multiaddr_to_socketaddr(addr: &Multiaddr) -> Option<SocketAddr> {


### PR DESCRIPTION
Add a bootstrap dial manager with exponential backoff + jitter to maintain min peer connectivity. Also add multi-hop rebroadcast + dedup to the simple TCP transport and align it with the versioned envelope wire wrapper.

Made-with: Cursor